### PR TITLE
v1.1.0: Add /recreate endpoint, switch to /unlock

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,13 +5,13 @@ ENV GOBIN /app/bin
 ENV PATH $GOBIN:$PATH
 
 # postgresql-support: Add the official postgres repo to install the matching postgresql-client tools of your stack
-# see https://wiki.postgresql.org/wiki/Apt
+# https://wiki.postgresql.org/wiki/Apt
 # run lsb_release -c inside the container to pick the proper repository flavor
-# e.g. stretch=>stretch-pgdg, buster=>buster-pgdg
-RUN echo "deb http://apt.postgresql.org/pub/repos/apt/ buster-pgdg main" \
+# e.g. stretch=>stretch-pgdg, buster=>buster-pgdg, bullseye=>bullseye-pgdg
+RUN echo "deb http://apt.postgresql.org/pub/repos/apt/ bullseye-pgdg main" \
     | tee /etc/apt/sources.list.d/pgdg.list \
-    && wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc \
-    | apt-key add -
+    && apt install curl ca-certificates gnupg \
+    && curl https://www.postgresql.org/media/keys/ACCC4CF8.asc | gpg --dearmor | tee /etc/apt/trusted.gpg.d/apt.postgresql.org.gpg >/dev/null
 
 # Install required system dependencies
 RUN apt-get update \
@@ -49,7 +49,7 @@ RUN wget https://github.com/kyoh86/richgo/releases/download/v0.3.3/richgo_0.3.3_
 RUN curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh \
     | sh -s -- -b $(go env GOPATH)/bin v1.24.0
 
-# go swagger: (this package should NOT be installed via go get) 
+# go swagger: (this package should NOT be installed via go get)
 # https://github.com/go-swagger/go-swagger/releases
 RUN curl -o /usr/local/bin/swagger -L'#' \
     "https://github.com/go-swagger/go-swagger/releases/download/v0.23.0/swagger_linux_amd64" \

--- a/client.go
+++ b/client.go
@@ -245,8 +245,8 @@ func (c *Client) ReturnTestDatabase(ctx context.Context, hash string, id int) er
 	}
 }
 
-func (c *Client) RestoreTestDatabase(ctx context.Context, hash string, id int) error {
-	req, err := c.newRequest(ctx, "POST", fmt.Sprintf("/templates/%s/tests/%d/restore", hash, id), nil)
+func (c *Client) RecreateTestDatabase(ctx context.Context, hash string, id int) error {
+	req, err := c.newRequest(ctx, "POST", fmt.Sprintf("/templates/%s/tests/%d/recreate", hash, id), nil)
 	if err != nil {
 		return err
 	}

--- a/client.go
+++ b/client.go
@@ -245,6 +245,29 @@ func (c *Client) ReturnTestDatabase(ctx context.Context, hash string, id int) er
 	}
 }
 
+func (c *Client) RestoreTestDatabase(ctx context.Context, hash string, id int) error {
+	req, err := c.newRequest(ctx, "POST", fmt.Sprintf("/templates/%s/tests/%d/restore", hash, id), nil)
+	if err != nil {
+		return err
+	}
+
+	resp, err := c.do(req, nil)
+	if err != nil {
+		return err
+	}
+
+	switch resp.StatusCode {
+	case http.StatusNoContent:
+		return nil
+	case http.StatusNotFound:
+		return ErrTemplateNotFound
+	case http.StatusServiceUnavailable:
+		return ErrManagerNotReady
+	default:
+		return fmt.Errorf("received unexpected HTTP status %d (%s)", resp.StatusCode, resp.Status)
+	}
+}
+
 func (c *Client) newRequest(ctx context.Context, method string, endpoint string, body interface{}) (*http.Request, error) {
 	u := c.baseURL.ResolveReference(&url.URL{Path: path.Join(c.baseURL.Path, endpoint)})
 


### PR DESCRIPTION
Required changes:
* Adds support for `POST /api/v1/templates/:hash/tests/:id/recreate`.
* **TODO**: `DELETE /api/v1/templates/:hash/tests/:id` is deprecated in favor of `POST /api/v1/templates/:hash/tests/:id/unlock`.

Ref:
* https://github.com/allaboutapps/integresql-client-go/issues/4
* [IntegreSQL v1.1.0](https://github.com/allaboutapps/integresql/blob/master/CHANGELOG.md#v110)